### PR TITLE
Update host port to 3000

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ $ cd /vagrant
 $ FLASK_APP=service:app flask run -h 0.0.0.0
 ```
 
-Now open your browser, you are expected to see the following text when browsing http://0.0.0.0:5000
+Now open your browser, you are expected to see the following text when browsing http://localhost:3000
 
 ```json
 {
   "name": "Inventory REST API Service",
-  "paths": "http://0.0.0.0:5000/inventory",
+  "paths": "http://localhost:3000/inventory",
   "version": "1.0"
 }
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = "ubuntu"
 
   # set up network ip and port forwarding
-  config.vm.network "forwarded_port", guest: 5000, host: 5000, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 5000, host: 3000, host_ip: "127.0.0.1"
   config.vm.network "private_network", ip: "192.168.33.10"
 
   # Windows users need to change the permission of files and directories


### PR DESCRIPTION
Update host port to `3000` due to macOS Monterey has a control center that listens on port `5000`.
You can see some discussion [here](https://www.reddit.com/r/webdev/comments/qg8yt9/apple_took_over_port_5000_in_the_latest_macos/).

- Update Vagrantfile's host port
- Correct wordings in README.md